### PR TITLE
feat: upstream parity — Line.Truncated + file-content stream overload

### DIFF
--- a/src/Bitbucket.Net/Core/Projects/BitbucketClient.Branches.cs
+++ b/src/Bitbucket.Net/Core/Projects/BitbucketClient.Branches.cs
@@ -268,8 +268,9 @@ public partial class BitbucketClient
     }
 
     /// <summary>
-    /// Updates a file at the specified path in the repository.
-    /// Uses ArrayPool&lt;byte&gt; for zero-copy buffer management to minimize heap allocations.
+    /// Updates a file at the specified path in the repository from a file on disk.
+    /// Uses ArrayPool&lt;byte&gt; for zero-copy buffer management to minimize heap allocations,
+    /// then delegates to the stream overload to perform the upload.
     /// </summary>
     public async Task<Commit> UpdateProjectRepositoryPathAsync(string projectKey, string repositorySlug, string path,
         string fileName,
@@ -303,25 +304,54 @@ public partial class BitbucketClient
             // Create MemoryStream over the exact bytes read (not the rented buffer size)
             using var memoryStream = new MemoryStream(buffer, 0, bytesRead, writable: false);
 
-            var data = new DynamicMultipartFormDataContent
-            {
-                { new StreamContent(memoryStream), "content" },
-                { new StringContent(branch), "branch" },
-                { message, message == null ? null : new StringContent(message), "message" },
-                { sourceCommitId, sourceCommitId == null ? null : new StringContent(sourceCommitId), "sourceCommitId" },
-                { sourceBranch, sourceBranch == null ? null : new StringContent(sourceBranch), "sourceBranch" },
-            };
-
-            var response = await GetProjectsReposUrl(projectKey, repositorySlug, $"/browse/{path}")
-                .PutAsync(data.ToMultipartFormDataContent(), cancellationToken: cancellationToken)
-                .ConfigureAwait(false);
-
-            return await HandleResponseAsync<Commit>(response, cancellationToken: cancellationToken).ConfigureAwait(false);
+            return await UpdateProjectRepositoryPathAsync(projectKey, repositorySlug, path, memoryStream, branch, message, sourceCommitId, sourceBranch, cancellationToken).ConfigureAwait(false);
         }
         finally
         {
             // Always return the buffer to the pool
             ArrayPool<byte>.Shared.Return(buffer);
         }
+    }
+
+    /// <summary>
+    /// Updates a file at the specified path in the repository from an in-memory content stream,
+    /// without requiring a file on disk. For string content, wrap it in a stream
+    /// (for example <c>new MemoryStream(System.Text.Encoding.UTF8.GetBytes(content))</c>).
+    /// </summary>
+    /// <param name="projectKey">The project key.</param>
+    /// <param name="repositorySlug">The repository slug.</param>
+    /// <param name="path">The file path within the repository.</param>
+    /// <param name="content">The new file content. The stream is read from its current position.</param>
+    /// <param name="branch">The branch to commit to.</param>
+    /// <param name="message">Optional commit message.</param>
+    /// <param name="sourceCommitId">Optional expected source commit id for optimistic locking.</param>
+    /// <param name="sourceBranch">Optional source branch to create the target branch from.</param>
+    /// <param name="cancellationToken">Token to cancel the operation.</param>
+    /// <returns>The commit produced by the update.</returns>
+    public async Task<Commit> UpdateProjectRepositoryPathAsync(string projectKey, string repositorySlug, string path,
+        Stream content,
+        string branch,
+        string? message = null,
+        string? sourceCommitId = null,
+        string? sourceBranch = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+        ArgumentNullException.ThrowIfNull(content);
+
+        var data = new DynamicMultipartFormDataContent
+        {
+            { new StreamContent(content), "content" },
+            { new StringContent(branch), "branch" },
+            { message, message == null ? null : new StringContent(message), "message" },
+            { sourceCommitId, sourceCommitId == null ? null : new StringContent(sourceCommitId), "sourceCommitId" },
+            { sourceBranch, sourceBranch == null ? null : new StringContent(sourceBranch), "sourceBranch" },
+        };
+
+        var response = await GetProjectsReposUrl(projectKey, repositorySlug, $"/browse/{path}")
+            .PutAsync(data.ToMultipartFormDataContent(), cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+
+        return await HandleResponseAsync<Commit>(response, cancellationToken: cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/Bitbucket.Net/Core/Projects/IBranchOperations.cs
+++ b/src/Bitbucket.Net/Core/Projects/IBranchOperations.cs
@@ -23,4 +23,5 @@ public interface IBranchOperations
     Task<Stream> GetRawFileContentStreamAsync(string projectKey, string repositorySlug, string path, string? at = null, CancellationToken cancellationToken = default);
     IAsyncEnumerable<string> GetRawFileContentLinesStreamAsync(string projectKey, string repositorySlug, string path, string? at = null, CancellationToken cancellationToken = default);
     Task<Commit> UpdateProjectRepositoryPathAsync(string projectKey, string repositorySlug, string path, string fileName, string branch, string? message = null, string? sourceCommitId = null, string? sourceBranch = null, CancellationToken cancellationToken = default);
+    Task<Commit> UpdateProjectRepositoryPathAsync(string projectKey, string repositorySlug, string path, Stream content, string branch, string? message = null, string? sourceCommitId = null, string? sourceBranch = null, CancellationToken cancellationToken = default);
 }

--- a/src/Bitbucket.Net/Models/Core/Projects/Line.cs
+++ b/src/Bitbucket.Net/Models/Core/Projects/Line.cs
@@ -1,6 +1,19 @@
 namespace Bitbucket.Net.Models.Core.Projects;
 
+/// <summary>
+/// A single line of file content returned when browsing a repository path.
+/// </summary>
 public class Line
 {
+    /// <summary>
+    /// The text of the line.
+    /// </summary>
     public string? Text { get; init; }
+
+    /// <summary>
+    /// <see langword="true"/> when Bitbucket truncated this line because it exceeded the server's
+    /// maximum line length; otherwise <see langword="false"/> or <see langword="null"/> when the
+    /// server does not report truncation.
+    /// </summary>
+    public bool? Truncated { get; init; }
 }

--- a/test/Bitbucket.Net.Tests/MockTests/RepositoryFileUpdateMockTests.cs
+++ b/test/Bitbucket.Net.Tests/MockTests/RepositoryFileUpdateMockTests.cs
@@ -1,0 +1,121 @@
+using Bitbucket.Net.Tests.Infrastructure;
+using System.Net;
+using System.Text;
+using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
+using Xunit;
+
+namespace Bitbucket.Net.Tests.MockTests;
+
+/// <summary>
+/// Covers <c>UpdateProjectRepositoryPathAsync</c> — the existing file-on-disk overload and the new
+/// stream overload that lets callers push in-memory content without writing a physical file.
+/// </summary>
+public class RepositoryFileUpdateMockTests(BitbucketMockFixture fixture) : IClassFixture<BitbucketMockFixture>
+{
+    private const string ProjectKey = "PRJ";
+    private const string RepoSlug = "repo";
+    private const string FilePath = "README.md";
+    private const string CommitJson = "{\"id\":\"abc123def456\",\"displayId\":\"abc123d\"}";
+
+    private readonly BitbucketMockFixture _fixture = fixture;
+
+    private string BrowsePath => $"/rest/api/1.0/projects/{ProjectKey}/repos/{RepoSlug}/browse/{FilePath}";
+
+    private void StubBrowsePut()
+    {
+        _fixture.Server
+            .Given(Request.Create().WithPath(BrowsePath).UsingPut())
+            .RespondWith(Response.Create()
+                .WithStatusCode(HttpStatusCode.OK)
+                .WithHeader("Content-Type", "application/json")
+                .WithBody(CommitJson));
+    }
+
+    private string SingleRequestBody(out string method)
+    {
+        var message = Assert.Single(_fixture.Server.LogEntries).RequestMessage;
+        method = message.Method;
+        return message.Body ?? (message.BodyAsBytes is { } bytes ? Encoding.UTF8.GetString(bytes) : string.Empty);
+    }
+
+    [Fact]
+    public async Task UpdateProjectRepositoryPathAsync_FromStream_PutsContentAndReturnsCommit()
+    {
+        _fixture.Reset();
+        StubBrowsePut();
+        var client = _fixture.CreateClient();
+
+        using var content = new MemoryStream(Encoding.UTF8.GetBytes("hello from a stream"));
+        var commit = await client.UpdateProjectRepositoryPathAsync(
+            ProjectKey, RepoSlug, FilePath, content, "main", message: "update readme");
+
+        Assert.NotNull(commit);
+        Assert.Equal("abc123def456", commit.Id);
+
+        var body = SingleRequestBody(out var method);
+        Assert.Equal("PUT", method, StringComparer.OrdinalIgnoreCase);
+        Assert.Contains("hello from a stream", body);
+        Assert.Contains("main", body);
+        Assert.Contains("update readme", body);
+    }
+
+    [Fact]
+    public async Task UpdateProjectRepositoryPathAsync_FromFile_ReadsFileAndReturnsCommit()
+    {
+        _fixture.Reset();
+        StubBrowsePut();
+        var client = _fixture.CreateClient();
+
+        var tempFile = Path.GetTempFileName();
+        try
+        {
+            await File.WriteAllTextAsync(tempFile, "hello from a file");
+
+            var commit = await client.UpdateProjectRepositoryPathAsync(
+                ProjectKey, RepoSlug, FilePath, tempFile, "main");
+
+            Assert.NotNull(commit);
+            Assert.Equal("abc123def456", commit.Id);
+
+            var body = SingleRequestBody(out var method);
+            Assert.Equal("PUT", method, StringComparer.OrdinalIgnoreCase);
+            Assert.Contains("hello from a file", body);
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public async Task UpdateProjectRepositoryPathAsync_FromStream_NullContent_Throws()
+    {
+        var client = _fixture.CreateClient();
+
+        await Assert.ThrowsAsync<ArgumentNullException>(() =>
+            client.UpdateProjectRepositoryPathAsync(ProjectKey, RepoSlug, FilePath, (Stream)null!, "main"));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task UpdateProjectRepositoryPathAsync_FromStream_BlankPath_Throws(string path)
+    {
+        var client = _fixture.CreateClient();
+        using var content = new MemoryStream(Encoding.UTF8.GetBytes("x"));
+
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+            client.UpdateProjectRepositoryPathAsync(ProjectKey, RepoSlug, path, content, "main"));
+    }
+
+    [Fact]
+    public async Task UpdateProjectRepositoryPathAsync_FromFile_MissingFile_Throws()
+    {
+        var client = _fixture.CreateClient();
+        var missing = Path.Combine(Path.GetTempPath(), $"bbnet-missing-{Guid.NewGuid():N}.txt");
+
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+            client.UpdateProjectRepositoryPathAsync(ProjectKey, RepoSlug, FilePath, missing, "main"));
+    }
+}

--- a/test/Bitbucket.Net.Tests/UnitTests/ModelSerializationTests.cs
+++ b/test/Bitbucket.Net.Tests/UnitTests/ModelSerializationTests.cs
@@ -12,6 +12,72 @@ namespace Bitbucket.Net.Tests.UnitTests;
 
 public class ModelSerializationTests
 {
+    #region Line Serialization Tests
+
+    [Fact]
+    public void Line_Deserialization_ReadsTruncatedFlag()
+    {
+        var json = """
+        {
+            "text": "a very long line that the server truncated",
+            "truncated": true
+        }
+        """;
+
+        var line = JsonSerializer.Deserialize(json, BitbucketJsonContext.Default.Line);
+
+        Assert.NotNull(line);
+        Assert.Equal("a very long line that the server truncated", line.Text);
+        Assert.True(line.Truncated);
+    }
+
+    [Fact]
+    public void Line_Deserialization_TruncatedNullWhenAbsent()
+    {
+        var json = """
+        {
+            "text": "short line"
+        }
+        """;
+
+        var line = JsonSerializer.Deserialize(json, BitbucketJsonContext.Default.Line);
+
+        Assert.NotNull(line);
+        Assert.Equal("short line", line.Text);
+        Assert.Null(line.Truncated);
+    }
+
+    [Fact]
+    public void Line_Deserialization_ReadsExplicitFalse()
+    {
+        var json = """
+        {
+            "text": "untruncated line",
+            "truncated": false
+        }
+        """;
+
+        var line = JsonSerializer.Deserialize(json, BitbucketJsonContext.Default.Line);
+
+        Assert.NotNull(line);
+        Assert.False(line.Truncated);
+    }
+
+    [Fact]
+    public void Line_Serialization_RoundTrips()
+    {
+        var line = new Line { Text = "round trip", Truncated = true };
+
+        var json = JsonSerializer.Serialize(line, BitbucketJsonContext.Default.Line);
+        var deserialized = JsonSerializer.Deserialize(json, BitbucketJsonContext.Default.Line);
+
+        Assert.NotNull(deserialized);
+        Assert.Equal(line.Text, deserialized.Text);
+        Assert.Equal(line.Truncated, deserialized.Truncated);
+    }
+
+    #endregion
+
     #region Project Serialization Tests
 
     [Fact]


### PR DESCRIPTION
## Summary

Two small, high-value fixes carried over from still-open issues on the original `lvermeulen/Bitbucket.Net`, both with full test coverage. We're the maintained fork, so we take the good suggestions and implement them properly.

## Changes

- **`Line.Truncated`** (`lvermeulen/Bitbucket.Net#30`) — Bitbucket sets `"truncated": true` on file lines that exceed the server's maximum line length when browsing a path. The `Line` model dropped that field, silently losing the signal. Now surfaced as `bool? Truncated`.
- **Update a file from a content stream** (`lvermeulen/Bitbucket.Net#29`) — `UpdateProjectRepositoryPathAsync` only accepted a path to a file on disk, forcing callers with in-memory content to write a temp file first. Added a `Stream content` overload (for string content, wrap it in a `MemoryStream`). The file-on-disk overload now delegates to it, preserving the existing `ArrayPool` fast path. Non-breaking: the new `Stream` parameter is distinct from the existing `string fileName`, so overload resolution stays unambiguous and the existing signature is untouched.

## Testing

- `ModelSerializationTests` — `Line` truncated `true` / `false` / absent (→ `null`) / round-trip.
- `RepositoryFileUpdateMockTests` — stream and file overloads PUT the expected content/branch/message and return the commit; plus null-content, blank-path, and missing-file guard tests.
- Full suite: **767 passing**, Release build clean under `TreatWarningsAsErrors`, format gate (`dotnet format` whitespace + style) green.
