### PR TITLE
build: multi-target net8.0 + net10.0, lock API surface — 1.0.0 prep

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,10 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '10.0.x'
+          # Install both runtimes so the net8.0 (LTS) and net10.0 targets can be built and tested.
+          dotnet-version: |
+            8.0.x
+            10.0.x
 
       - name: Restore
         run: dotnet restore

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,7 +28,10 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '10.0.x'
+          # Both runtimes are required to build and test the net8.0 (LTS) and net10.0 targets.
+          dotnet-version: |
+            8.0.x
+            10.0.x
 
       - name: Restore
         run: dotnet restore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.0.0] - 2026-06-05
 
-### Added
+First stable, publicly supported release. **Targets `net8.0` (LTS) and
+`net10.0`** and consolidates everything accumulated since 0.3.0 (the prior
+unreleased "1.0.0" modernization plus this release cycle).
+
+### Target frameworks & packaging
+
+- **Multi-targets `net8.0` (LTS) and `net10.0`** — previously net10.0-only,
+  which excluded the large base of consumers on .NET 8 LTS. (.NET 9 apps resolve
+  the `net8.0` assembly automatically via NuGet's nearest-compatible framework.)
+- **`EnablePackageValidation`** keeps the `net8.0` and `net10.0` API surfaces
+  compatible and, from the next release on, guards against accidental breaking
+  changes against the 1.0.0 baseline.
+- Moved the test toolchain from `WireMock.Net` to `WireMock.Net.Minimal`,
+  dropping a vulnerable transitive `OpenTelemetry 1.14.0` dependency and
+  restoring a clean `dotnet restore` / CI under the NuGet vulnerability audit.
+
+### Added — extensibility, filters & DX (this cycle)
 
 - **Protected extensibility surface** ([#4](https://github.com/diomonogatari/Bitbucket.Net/issues/4)):
   the low-level building blocks of `BitbucketClient` are now `protected`
@@ -30,16 +46,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`avatarSize` on `GetPullRequestCommentLikesAsync`**: added the
   `avatarSize` query parameter so the method matches its sibling
   `GetCommitCommentLikesAsync` (both return users). ([#4](https://github.com/diomonogatari/Bitbucket.Net/issues/4))
+- **`Line.Truncated`** — the file-browse `Line` model now surfaces the API's
+  `truncated` flag, which was previously dropped (implements
+  `lvermeulen/Bitbucket.Net#30`).
+- **Update a file from a `Stream`** — new `UpdateProjectRepositoryPathAsync`
+  overload to push in-memory content without writing a physical file first; for
+  string content, wrap it in a `MemoryStream` (implements
+  `lvermeulen/Bitbucket.Net#29`).
 
-### Testing
+### Tests (this cycle)
 
-- Added `ExtensibilityMockTests` proving a subclass can implement a custom
-  paged endpoint from the protected helpers (single- and multi-page).
-- Added `RepositorySearchMockTests` covering the `archived` filter
-  (`ACTIVE`/`ARCHIVED`/`ALL` transmitted; omitted on the base overload) and an
-  `avatarSize` transmission test on `GetPullRequestCommentLikesAsync`.
+- `ExtensibilityMockTests` — a subclass implements a custom paged endpoint from
+  the protected helpers (single- and multi-page).
+- `RepositorySearchMockTests` — the `archived` filter (`ACTIVE`/`ARCHIVED`/`ALL`
+  transmitted; omitted on the base overload).
+- `RepositoryFileUpdateMockTests` — the stream and file overloads of
+  `UpdateProjectRepositoryPathAsync`, plus null/blank/missing-file guards.
+- `Line` truncated-flag (true / false / absent / round-trip) and the
+  `avatarSize` transmission test.
 
-## [1.0.0] - 2026-02-12
+### Modernization (the 0.x → 1.0 overhaul)
+
+The breaking changes, additions, and internals below were drafted for the
+never-released February 2026 "1.0.0" and ship as part of this release.
 
 ### Breaking Changes
 
@@ -179,7 +208,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `await` uses `ConfigureAwait(false)`.
 - Added `InputValidationTests` (17 parameterized theories) covering
   null/empty/whitespace rejection for key path-segment parameters.
-- Total test count: 749.
+- Total test count at 1.0.0: 767 (across `net8.0` and `net10.0`).
 
 ## [0.3.0] - 2026-02-010
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ If you're looking for Bitbucket Cloud API, try [this repository](https://github.
 dotnet add package BitbucketServer.Net
 ```
 
+Targets **.NET 8.0 (LTS)** and **.NET 10.0**. .NET 9 projects consume the
+`net8.0` assembly automatically.
+
 ## Usage
 
 ### Basic Authentication

--- a/benchmarks/Bitbucket.Net.Benchmarks/Bitbucket.Net.Benchmarks.csproj
+++ b/benchmarks/Bitbucket.Net.Benchmarks/Bitbucket.Net.Benchmarks.csproj
@@ -2,7 +2,11 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    
+
+    <!-- Benchmarks are a dev tool; build/run only on the latest runtime (overrides the
+         repo-wide multi-targeting in Directory.Build.props). -->
+    <TargetFrameworks>net10.0</TargetFrameworks>
+
     <!-- Benchmarks should always run in Release mode -->
     <Configuration Condition="'$(Configuration)' == ''">Release</Configuration>
     

--- a/src/Bitbucket.Net/Bitbucket.Net.csproj
+++ b/src/Bitbucket.Net/Bitbucket.Net.csproj
@@ -18,6 +18,12 @@
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <!-- Enforce ConfigureAwait(false) as this is a library -->
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <!-- Lock the public/protected API surface at pack time: validates that the net8.0 and net10.0
+         targets expose a compatible surface, and (once the baseline below is set after 1.0.0 ships)
+         flags accidental breaking changes against the previous release. -->
+    <EnablePackageValidation>true</EnablePackageValidation>
+    <!-- After 1.0.0 is published to NuGet, uncomment so 1.0.x / 1.x are checked against it:
+    <PackageValidationBaselineVersion>1.0.0</PackageValidationBaselineVersion> -->
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Bitbucket.Net.Tests/UnitTests/DiffStreamingExtensionsTests.cs
+++ b/test/Bitbucket.Net.Tests/UnitTests/DiffStreamingExtensionsTests.cs
@@ -120,7 +120,7 @@ public class DiffStreamingExtensionsTests
     [Fact]
     public async Task StreamDiffsWithLimitsAsync_Empty_YieldsNothing()
     {
-        var diffs = AsyncEnumerable.Empty<Diff>();
+        var diffs = CreateDiffsAsync(0, 0);
 
         var results = await ToListAsync(diffs.StreamDiffsWithLimitsAsync());
 
@@ -191,7 +191,7 @@ public class DiffStreamingExtensionsTests
     [Fact]
     public async Task TakeDiffsWithLimitsAsync_Empty_ReturnsEmpty()
     {
-        var diffs = AsyncEnumerable.Empty<Diff>();
+        var diffs = CreateDiffsAsync(0, 0);
 
         var result = await diffs.TakeDiffsWithLimitsAsync();
 


### PR DESCRIPTION
## Summary

Prep for the first stable **1.0.0** release. This addresses the net10-only lock and the pre-1.0.0 checklist. **It does not release anything** — publishing still happens via a tagged GitHub Release, which is a separate, deliberate step.

## What's in here

### Multi-target `net8.0` (LTS) + `net10.0`
The library was **net10.0-only**, which excluded most consumers (net8 LTS is the bulk of production; net9 is STS). Now multi-targets `net8.0;net10.0`:
- `Directory.Build.props`: `TargetFramework` → `TargetFrameworks net8.0;net10.0` (library + tests; **tests run on both runtimes**).
- Benchmarks pinned to net10.0 (dev tool).
- One net10-only test API (`System.Linq.AsyncEnumerable.Empty`) swapped for the existing TFM-agnostic helper — **the library itself had zero net10-only APIs**.
- CI + publish install both `8.0.x` and `10.0.x`.
- **767 tests pass on net8.0 and net10.0**; the package ships `lib/net8.0` + `lib/net10.0`.

### Lock the API surface — `EnablePackageValidation`
Pack now validates the net8.0/net10.0 surfaces are compatible, and (once `PackageValidationBaselineVersion` is set after 1.0.0 ships) will flag accidental breaking changes vs the baseline. Lower-maintenance and multi-target-aware vs hand-maintained PublicAPI.txt files.

### Reconcile the changelog + version
No 1.0.0 was ever published (latest on NuGet is **0.3.0**); the `[1.0.0] - 2026-02-12` entry was aspirational. Consolidated everything since 0.3.0 into one honest, dated `1.0.0` entry (target frameworks/packaging + this cycle's extensibility/filters/DX + the folded-in modernization). README notes net8/net10 support.
