### PR TITLE
build: lock the API surface against the 1.0.0 baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,11 @@ jobs:
           --collect:"XPlat Code Coverage"
           --results-directory ./coverage
 
+      # Runs Package Validation (EnablePackageValidation) so an accidental API break vs the
+      # published baseline fails the PR here, not only at release time.
+      - name: Pack (API baseline validation)
+        run: dotnet pack src/Bitbucket.Net/Bitbucket.Net.csproj --no-build -c Release -o ./artifacts
+
       - name: Upload coverage
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: codecov/codecov-action@v4

--- a/src/Bitbucket.Net/Bitbucket.Net.csproj
+++ b/src/Bitbucket.Net/Bitbucket.Net.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PackageId>BitbucketServer.Net</PackageId>
-    <Version>1.0.0</Version>
+    <Version>1.0.1</Version>
     <Authors>Diogo Carvalho</Authors>
     <Description>Modernized fork of Bitbucket.Net — C# client for Bitbucket Server (Stash) REST API. Adds streaming, CancellationToken support, System.Text.Json, typed exceptions, and Bitbucket Server 9.0+ compatibility.</Description>
     <PackageTags>bitbucket;bitbucket-server;stash;rest-api;api-client;atlassian;sdk;dotnet</PackageTags>
@@ -22,8 +22,10 @@
          targets expose a compatible surface, and (once the baseline below is set after 1.0.0 ships)
          flags accidental breaking changes against the previous release. -->
     <EnablePackageValidation>true</EnablePackageValidation>
-    <!-- After 1.0.0 is published to NuGet, uncomment so 1.0.x / 1.x are checked against it:
-    <PackageValidationBaselineVersion>1.0.0</PackageValidationBaselineVersion> -->
+    <!-- 1.0.0 is the published API baseline: every build is diffed against it, so an accidental
+         breaking change (a removed/changed member, or a dropped target framework) fails the pack.
+         Bump this to the latest released version when intentionally shipping a new baseline. -->
+    <PackageValidationBaselineVersion>1.0.0</PackageValidationBaselineVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

Follow-up to the 1.0.0 release: now that `BitbucketServer.Net 1.0.0` is on NuGet, turn it into the **API baseline** so future releases can't silently break consumers.

## Changes

- **`PackageValidationBaselineVersion=1.0.0`** — every build now diffs its public/protected surface against the published 1.0.0. A removed/changed member, or a dropped target framework, **fails the pack** (`CP0002` etc.). Intentional breaks are acknowledged via a suppression file (`/p:ApiCompatGenerateSuppressionFile=true`) or a major-version bump + new baseline.
- **In-repo dev version → `1.0.1`** (PackageValidation needs the candidate to be higher than the baseline). The actual release version still comes from the git tag at publish time.
- **CI now runs `dotnet pack`** so the baseline check fails at **PR time**, not only at release.

## Verified

- **Negative test:** demoting a `protected` member (`GetBaseUrl`) failed pack with `CP0002` on **both** net8.0 and net10.0 — the lock genuinely bites.
- **Positive:** the unchanged `1.0.1` surface validates clean against the published `1.0.0`.
- 767 tests pass on both TFMs; format gate clean.

No release here — just hardening the pipeline for everything after 1.0.0.
